### PR TITLE
Only show MediaPlayerNotification when playing

### DIFF
--- a/detlef/src/at/ac/tuwien/detlef/activities/MainActivity.java
+++ b/detlef/src/at/ac/tuwien/detlef/activities/MainActivity.java
@@ -72,7 +72,6 @@ import at.ac.tuwien.detlef.gpodder.events.PlaylistChangedEvent;
 import at.ac.tuwien.detlef.gpodder.events.PullFeedResultEvent;
 import at.ac.tuwien.detlef.gpodder.events.PullSubscriptionResultEvent;
 import at.ac.tuwien.detlef.gpodder.events.SubscriptionsChangedEvent;
-import at.ac.tuwien.detlef.mediaplayer.MediaPlayerNotification;
 import at.ac.tuwien.detlef.settings.GpodderSettings;
 import de.greenrobot.event.EventBus;
 
@@ -131,8 +130,6 @@ public class MainActivity extends FragmentActivity
         if (refreshBg == null) {
             refreshBg = Executors.newSingleThreadExecutor();
         }
-
-        MediaPlayerNotification.create(this, false, null);
 
         // Create the adapter that will return a fragment for each of the three
         // primary sections of the app.

--- a/detlef/src/at/ac/tuwien/detlef/fragments/PlayerFragment.java
+++ b/detlef/src/at/ac/tuwien/detlef/fragments/PlayerFragment.java
@@ -49,6 +49,7 @@ import at.ac.tuwien.detlef.db.PlaylistDAO;
 import at.ac.tuwien.detlef.domain.Episode;
 import at.ac.tuwien.detlef.domain.Episode.StorageState;
 import at.ac.tuwien.detlef.mediaplayer.IMediaPlayerService;
+import at.ac.tuwien.detlef.mediaplayer.MediaPlayerNotification;
 import at.ac.tuwien.detlef.mediaplayer.MediaPlayerService;
 
 public class PlayerFragment extends Fragment implements PlaylistDAO.OnPlaylistChangeListener,
@@ -347,6 +348,7 @@ public class PlayerFragment extends Fragment implements PlaylistDAO.OnPlaylistCh
         try {
             if (service.isCurrentlyPlaying()) {
                 stopPlaying();
+                MediaPlayerNotification.cancel((MediaPlayerService)service);
             } else {
                 startPlaying();
             }


### PR DESCRIPTION
Don't create a MediaPlayerNotification on start, but only when an episode is playing, and remove it again when pausing from the PlayerFragment.