### PR TITLE
Refs #61 - faster sync

### DIFF
--- a/detlef/src/at/ac/tuwien/detlef/domain/EnhancedSubscriptionChanges.java
+++ b/detlef/src/at/ac/tuwien/detlef/domain/EnhancedSubscriptionChanges.java
@@ -1,5 +1,5 @@
 /* *************************************************************************
- *  Copyright 2012 The detlef developers                                   *
+ *  Copyright 2012-2014 The detlef developers                              *
  *                                                                         *
  *  This program is free software: you can redistribute it and/or modify   *
  *  it under the terms of the GNU General Public License as published by   *
@@ -37,10 +37,10 @@ public class EnhancedSubscriptionChanges implements Serializable, Parcelable {
 
     private static final long serialVersionUID = 1L;
 
-    /** Added podcasts. */
+    /** Stubs for added podcasts. */
     private final List<Podcast> add;
 
-    /** Removed podcasts. */
+    /** Stubs for removed podcasts. */
     private final List<Podcast> remove;
 
     /** Timestamp of the changes. */
@@ -52,8 +52,8 @@ public class EnhancedSubscriptionChanges implements Serializable, Parcelable {
      * The Lists passed to the constuctor are copied into Lists of Podcast. The timestamp an all
      * Podcasts is set to the given timestamp.
      *
-     * @param add List of IPodcasts to add.
-     * @param remove List of IPodcasts to remove.
+     * @param add List of IPodcasts (stubs are OK) to add.
+     * @param remove List of IPodcasts (stubs are OK) to remove.
      * @param timestamp The timestamp of the changes.
      */
     public EnhancedSubscriptionChanges(List <? extends IPodcast > add,

--- a/detlef/src/at/ac/tuwien/detlef/domain/Podcast.java
+++ b/detlef/src/at/ac/tuwien/detlef/domain/Podcast.java
@@ -1,5 +1,5 @@
 /* *************************************************************************
- *  Copyright 2012 The detlef developers                                   *
+ *  Copyright 2012-2014 The detlef developers                              *
  *                                                                         *
  *  This program is free software: you can redistribute it and/or modify   *
  *  it under the terms of the GNU General Public License as published by   *
@@ -32,8 +32,9 @@ import at.ac.tuwien.detlef.R;
 import com.dragontek.mygpoclient.simple.IPodcast;
 
 /**
- * Dummy class to display initial test podcast content until the actual podcast
- * classes are available.
+ * A podcast object can hold all details of a podcast, or it can just contain
+ * it's url. In the latter case, I call it a stub. The isStub() method can be
+ * used to determine wheter the object is a stub or not.
  */
 public class Podcast implements IPodcast, Serializable, Parcelable {
 
@@ -210,6 +211,22 @@ public class Podcast implements IPodcast, Serializable, Parcelable {
 
     public void setLocalDel(boolean localDel) {
         this.localDel = localDel;
+    }
+
+    /**
+     * Indicates whether the podcast details still have to be fetched.
+     *
+     * @return true if the podcast details still have to be fetched.
+     */
+    public boolean isStub() {
+        /*
+         * At the moment, I check whether the podcast has a logoFilePath to
+         * decide whether all details are available or not. This is probably
+         * not the best way to do this. On the other hand, when some cover
+         * art is missing for one or another reason, this will make detlef
+         * redownload it with the next refresh.
+         */
+        return (this.logoFilePath == null || this.logoFilePath.isEmpty());
     }
 
     @Override

--- a/detlef/src/at/ac/tuwien/detlef/gpodder/PodcastSaver.java
+++ b/detlef/src/at/ac/tuwien/detlef/gpodder/PodcastSaver.java
@@ -1,0 +1,73 @@
+/* *************************************************************************
+ *  Copyright 2012-2014 The detlef developers                              *
+ *                                                                         *
+ *  This program is free software: you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation, either version 2 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *  You should have received a copy of the GNU General Public License      *
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.  *
+ ************************************************************************* */
+
+package at.ac.tuwien.detlef.gpodder;
+
+import android.util.Log;
+import at.ac.tuwien.detlef.Singletons;
+import at.ac.tuwien.detlef.db.PodcastDAO;
+import at.ac.tuwien.detlef.domain.Podcast;
+
+/**
+ * Class to save or update podcast or stub.
+ *
+ * There might be a better place to define this function. I am not
+ * sure yet where.
+ */
+public final class PodcastSaver {
+    private static final String TAG = PodcastSaver.class.getName();
+
+    /**
+     * Adds or updates a podcast into the database.
+     *
+     * @param p podcast to be saved
+     * @param asRemote if true, the podcast is saved as remote podcast. If false, local/remote is untouched.
+     */
+    public static void savePodcast(Podcast p, boolean asRemote) {
+        /*
+         * If the podcast has no title, it is probably a stub.
+         * Temporarily use the url as title.
+         */
+        if (p.getTitle() == null || p.getTitle().isEmpty()){
+            p.setTitle(p.getUrl());
+        }
+
+        PodcastDAO dao = Singletons.i().getPodcastDAO();
+
+        Podcast pod = dao.getPodcastByUrl(p.getUrl());
+        if (pod != null) {
+            /* The podcast may already be in the local add/delete table. */
+            if (asRemote && (pod.isLocalAdd() || pod.isLocalDel())) {
+                dao.setRemotePodcast(pod);
+                /* Now the podcast is assumed to be remote. */
+            }
+
+            /* Overwrite the details. */
+            dao.update(p);
+            return;
+        }
+
+        if (p.getUrl() != null) {
+            /* If no title was available, we've copied the url */
+            assert(p.getTitle() != null);
+            dao.insertPodcast(p);
+        } else {
+            Log.w(TAG, "Cannot insert podcast without url");
+        }
+    }
+}
+


### PR DESCRIPTION
I improved the sync time; it is now twice as fast.

Step 1: At the time the subscriptions are synced, for the remotely added podcasts, only the url is stored in the database. (I call this a podcast stub.)
Step 2: The podcast details (name, album art, ...) are stored at the time the feed is parsed to get the episode information (which is the directly after the subscriptions are synced).

Before this refactoring, each feed was completely parsed as well in stap 1 as in step 2. Eliminating one parse operation halves the time of a sync operation, because parsing large feeds seems to take a lot of time.

I created a new class 'PodcastSaver' with one static method, because I did not know where this particular method has to be defined. What it does, is checking whether the podcast already exists, and add it to the DB  or mark it as remote if needed. This method is used by both PullFeedAsyncTask and SyncSubscriptionsAsyncTask.
